### PR TITLE
Support Internet Explorer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,15 +5,15 @@ export default function (obj) {
 	var locale='', tree = obj || {};
 
 	return {
-		set(lang, table) {
+		set: function (lang, table) {
 			tree[lang] = Object.assign(tree[lang] || {}, table);
 		},
 
-		locale(lang) {
+		locale: function (lang) {
 			locale = lang;
 		},
 
-		t(key, params, lang) {
+		t: function (key, params, lang) {
 			var val = dlv(tree[lang || locale], key, '');
 			if (typeof val === 'function') return val(params);
 			if (typeof val === 'string') return tmpl(val, params);


### PR DESCRIPTION
Internet Explorer does not support implicit field names for object methods.