### PR TITLE
Add pluralization support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,14 +14,14 @@
   </a>
 </div>
 
-<div align="center">A general purpose internationalization library in 338 bytes!</div>
+<div align="center">A general purpose internationalization library in 352 bytes!</div>
 
 ## Features
 
 * Simple and Familiar API
 * Unobstrusive and Unopinionated
 * Supports pluralization
-* Less than 350 bytes – including dependencies!
+* 352 bytes – including dependencies!
 
 
 ## Install

--- a/readme.md
+++ b/readme.md
@@ -14,14 +14,14 @@
   </a>
 </div>
 
-<div align="center">A general purpose internationalization library in 352 bytes!</div>
+<div align="center">A general purpose internationalization library in 348 bytes!</div>
 
 ## Features
 
 * Simple and Familiar API
 * Unobstrusive and Unopinionated
 * Supports pluralization
-* 352 bytes – including dependencies!
+* Less than 350 bytes – including dependencies!
 
 
 ## Install

--- a/readme.md
+++ b/readme.md
@@ -14,13 +14,14 @@
   </a>
 </div>
 
-<div align="center">A general purpose internationalization library in 298 bytes!</div>
+<div align="center">A general purpose internationalization library in 338 bytes!</div>
 
 ## Features
 
 * Simple and Familiar API
 * Unobstrusive and Unopinionated
-* Less than 300 bytes – including dependencies!
+* Supports pluralization
+* Less than 350 bytes – including dependencies!
 
 
 ## Install
@@ -40,6 +41,11 @@ const i18n = rosetta({
     intro: {
       welcome: 'Welcome, {{username}}!',
       text: 'I hope you find this useful.',
+      results_count: {
+        zero: '{{count}} results',
+        one: '{{count}} result',
+        other: '{{count}} results'
+      }
     },
     support(obj) {
       let hour = Math.floor(Math.random() * 3) + 9;
@@ -82,6 +88,10 @@ const data = {
 i18n.t('intro.welcome', data); //=> 'Welcome, lukeed!'
 i18n.t('intro.text', data); //=> 'I hope you find this useful.'
 i18n.t('support', data); //=> 'For questions, I'm available on 4/8/2020, any time after 11:00.'
+
+// Use plural rules for key ending by _count
+i18n.t('intro.results_count', {count: 0}); //=> 0 results
+i18n.t('intro.results_count', {count: 1}); //=> 1 result
 
 // Retrieve translations w/ lang override
 i18n.t('intro.welcome', data, 'pt'); //=> 'Benvindo, lukeed!'
@@ -347,6 +357,12 @@ The library makes use of [Object shorthand methods](https://developer.mozilla.or
 | 45+ | 9+ | 34+ | 12+ | :x: | 4.0+ |
 
 If you need to support older platforms, simply attach `rosetta` to your project's Babel (or similar) configuration.
+
+If you are using the plural rules features, you need a browser with `Intl.PluralRules` support:
+
+| Chrome | Safari | Firefox | Edge | IE | Node.js |
+|:------:|:------:|:-------:|:----:|:---:|:----:|
+|  63+   |  13+   |   58+   | 79+  | :x: | 4.0+ |
 
 ## Examples
 

--- a/src/debug.js
+++ b/src/debug.js
@@ -37,8 +37,8 @@ export default function (obj) {
 			}
 
 			if (typeof val === 'object' && key.endsWith('_count') && params.hasOwnProperty('count')) {
-				const count = params.count;
-				let pluralRuleToUse = '';
+				let count = params.count,
+					pluralRuleToUse = '';
 
 				if (count === 0 && val.hasOwnProperty('zero')) {
 					pluralRuleToUse = 'zero';

--- a/src/debug.js
+++ b/src/debug.js
@@ -2,7 +2,7 @@ import dlv from 'dlv';
 import tmpl from 'templite';
 
 export default function (obj) {
-	let locale='', tree = obj || {};
+	let locale='', tree = obj || {}, pluralRulesFormatters = {};
 
 	return {
 		set(lang, table) {
@@ -15,6 +15,10 @@ export default function (obj) {
 
 		table(lang) {
 			return tree[lang];
+		},
+
+		pluralRulesFormatter(lang) {
+			return pluralRulesFormatters[lang] = pluralRulesFormatters[lang] || new Intl.PluralRules('en');
 		},
 
 		t(key, params, lang) {
@@ -41,7 +45,7 @@ export default function (obj) {
 				} else if (count === 1 && val.hasOwnProperty('one')) {
 					pluralRuleToUse = 'one';
 				} else {
-					pluralRuleToUse = pluralRulesFormatters[lang || locale].select(count);
+					pluralRuleToUse = this.pluralRulesFormatter([lang || locale]).select(count);
 				}
 
 				if (!val.hasOwnProperty(pluralRuleToUse)) {

--- a/src/index.js
+++ b/src/index.js
@@ -33,8 +33,8 @@ export default function (obj) {
 			}
 
 			if (typeof val === 'object' && key.endsWith('_count') && params.hasOwnProperty('count')) {
-				const count = params.count;
-				let pluralRuleToUse = '';
+				let count = params.count,
+					pluralRuleToUse = '';
 
 				if (count === 0 && val.hasOwnProperty('zero')) {
 					pluralRuleToUse = 'zero';

--- a/src/index.js
+++ b/src/index.js
@@ -10,15 +10,15 @@ export default function (obj) {
 		},
 
 		locale(lang) {
-			if (lang) {
-				pluralRulesFormatters[lang] = pluralRulesFormatters[lang] || new Intl.PluralRules('en');
-			}
-
 			return (locale = lang || locale);
 		},
 
 		table(lang) {
 			return tree[lang];
+		},
+
+		pluralRulesFormatter(lang) {
+			return pluralRulesFormatters[lang] = pluralRulesFormatters[lang] || new Intl.PluralRules('en');
 		},
 
 		t(key, params, lang) {
@@ -41,7 +41,7 @@ export default function (obj) {
 				} else if (count === 1 && val.hasOwnProperty('one')) {
 					pluralRuleToUse = 'one';
 				} else {
-					pluralRuleToUse = pluralRulesFormatters[lang || locale].select(count);
+					pluralRuleToUse = this.pluralRulesFormatter([lang || locale]).select(count);
 				}
 
 				if (val.hasOwnProperty(pluralRuleToUse)) {

--- a/test/index.js
+++ b/test/index.js
@@ -181,6 +181,34 @@ test('arrays', () => {
 	);
 });
 
+test('plural_rules', () => {
+	let ctx = rosetta({
+		en: {
+			results_count: {
+				zero: "{{count}} results",
+				one: "{{count}} result",
+				other: "{{count}} results"
+			},
+
+			results_with_terms_count: {
+				one: "{{count}} result for {{terms}}",
+				other: "{{count}} results for {{terms}}"
+			}
+		}
+	});
+
+	ctx.locale('en');
+
+	assert.is(
+		ctx.t('results_count', {count: 1}),
+		'1 result'
+	);
+
+	assert.is(
+		ctx.t('results_with_terms_count', {count: 5, terms: 'bar'}),
+		'5 results for bar'
+	);
+});
 
 test('invalid value', () => {
 	let ctx = rosetta({


### PR DESCRIPTION
Hi !

I was looking for a minimal i18n solution and this seemed perfect, however it was lacking a somewhat essential feature: pluralization. It appears browser support for plural rules is now very good.

The syntax used is the one that Shopify uses for Liquid, and that provides a good balance of flexibility.

The bundle size increased from 298 to 348 bytes, which seems to be acceptable considering the addition :)

Let me know if you have any comment !

This should be backward compatible as well.